### PR TITLE
Fix Azure Static Web Apps deploy failing on forked PRs

### DIFF
--- a/.github/workflows/azure-static-web-apps-thankful-stone-0764a7f1e.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-stone-0764a7f1e.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
@@ -60,7 +60,7 @@ jobs:
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:
@@ -69,4 +69,5 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_THANKFUL_STONE_0764A7F1E }}
+          app_location: "_site" # Required input for the action, even on close
           action: "close"


### PR DESCRIPTION
Skip deployment steps when workflows run from forked repositories where secrets are not available. Prevents missing deployment_token errors while still allowing builds to run.